### PR TITLE
Remove background colors from non-current days

### DIFF
--- a/ZukiShell/gnome-shell/gnome-shell.css
+++ b/ZukiShell/gnome-shell/gnome-shell.css
@@ -1545,13 +1545,12 @@ StScrollBar StButton#vhandle:active {
 
 /* Hack used in lieu of border-collapse - see calendar.js */
 .calendar-day {
-	border: 1px solid #1d1d1d;
+	border: 1px solid rgba(0,0,0,0);
 	color: #eee;
 	border-top-width: 0;
 	border-left-width: 0;
 	width: 32px;
-	background-color: #363636;
-	box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.05);
+	height: 32px;
 }
 
 .calendar-day-top {
@@ -1566,7 +1565,6 @@ StScrollBar StButton#vhandle:active {
 }
 
 .calendar-nonwork-day {
-	background-color: #2f2f2f;
 }
 
 .calendar-today {
@@ -1582,7 +1580,6 @@ StScrollBar StButton#vhandle:active {
 
 .calendar-other-month-day {
 	color: #777;
-	background-color: #1d1d1d;
 	box-shadow: none;
 }
 


### PR DESCRIPTION
The new GNOME 3.16 calendar design features a new look with round day highlights. The current version of the zuki shell theme has a background color set for each day, which looks a bit weird (left picture). This PR removes the background color and border of all days but the current (and/or selected or hovered days) (right picture).

![old_new](https://cloud.githubusercontent.com/assets/2951180/7102353/161e7a3e-e07e-11e4-85e6-21e0ed6a7244.png)
