### PR TITLE
Fixes the text and bg colors of the undo popup in Nautilus

### DIFF
--- a/Zukitwo/gtk-3.0/gtk-widgets.css
+++ b/Zukitwo/gtk-3.0/gtk-widgets.css
@@ -130,7 +130,7 @@ GtkTextView {
 .app-notification,
 .app-notification.frame {
 	color: @theme_text_color;
-        background-color: alpha(@theme_bg_color, 0.35);
+        background-color: alpha(@theme_base_color, 0.85);
 	outline-color: @theme_bg_color;
 	text-shadow: none;
 	icon-shadow: none; 

--- a/Zukitwo/gtk-3.0/gtk-widgets.css
+++ b/Zukitwo/gtk-3.0/gtk-widgets.css
@@ -129,7 +129,8 @@ GtkTextView {
 /* Zuki-theme FIXME: Figure out what this is. */
 .app-notification,
 .app-notification.frame {
-	color: @theme_base_color;
+	color: @theme_text_color;
+        background-color: alpha(@theme_bg_color, 0.35);
 	outline-color: @theme_bg_color;
 	text-shadow: none;
 	icon-shadow: none; 


### PR DESCRIPTION
This fixes the text and bg colors of the undo popup in Nautilus when you move a file into trash. I guess this is app notification that you were wondering about?