### PR TITLE
Replace Ruby/sass with sassc

### DIFF
--- a/Zuki-shell/gnome-shell/parse-sass.sh
+++ b/Zuki-shell/gnome-shell/parse-sass.sh
@@ -1,3 +1,14 @@
-#!/usr/bin/bash
+#! /bin/bash
 
-bundle exec sass --update --sourcemap=none .
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t compact"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-contained.scss gtk-contained.css
+sassc $SASSC_OPT gtk-contained-dark.scss gtk-contained-dark.css
+

--- a/Zukitre/gtk-3.0/parse-sass.sh
+++ b/Zukitre/gtk-3.0/parse-sass.sh
@@ -1,3 +1,14 @@
-#!/bin/sh
+#! /bin/bash
 
-bundle exec sass --update --sourcemap=none .
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t compact"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-contained.scss gtk-contained.css
+sassc $SASSC_OPT gtk-contained-dark.scss gtk-contained-dark.css
+

--- a/Zukitwo/gtk-3.0/parse-sass.sh
+++ b/Zukitwo/gtk-3.0/parse-sass.sh
@@ -1,3 +1,14 @@
-#!/bin/sh
+#! /bin/bash
 
-bundle exec sass --update --sourcemap=none .
+if [ ! "$(which sassc 2> /dev/null)" ]; then
+   echo sassc needs to be installed to generate the css.
+   exit 1
+fi
+
+SASSC_OPT="-M -t compact"
+
+echo Generating the css...
+
+sassc $SASSC_OPT gtk-contained.scss gtk-contained.css
+sassc $SASSC_OPT gtk-contained-dark.scss gtk-contained-dark.css
+


### PR DESCRIPTION
Upstream Adwaita replaced the Ruby tools for parsing and building
the CSS files with a simpler sassc program which is using libsass.
More information here: https://github.com/sass/sassc

***

This is a minor change which shouldn't even be noticeable when building the theme. As mentioned in #116 it's just slightly more convenient packaging wise.
On top of that, the [README file in the gtk-3.0 directories](https://github.com/lassekongo83/zuki-themes/blob/master/Zukitre/gtk-3.0/README#L6) already mentions the usage of sassc.

I checked the repositories of the major distributions and they all have sassc in their repository.

* Ubuntu
https://packages.ubuntu.com/yakkety/sassc
* Fedora
https://admin.fedoraproject.org/pkgdb/package/rpms/sassc/
* Debian
https://packages.debian.org/stretch/sassc
* openSUSE
https://build.opensuse.org/package/show/openSUSE%3AFactory/sassc
* Arch
https://www.archlinux.org/packages/community/x86_64/sassc/