### PR TITLE
height to 2em and more background tranparency for blyr extension

### DIFF
--- a/Zuki-shell/gnome-shell/gnome-shell.css
+++ b/Zuki-shell/gnome-shell/gnome-shell.css
@@ -352,7 +352,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active { backg
 .tile-preview-left.tile-preview-right.on-primary { border-radius: 0px 0px 0 0; }
 
 /* TOP BAR */
-#panel { background-color: rgba(0, 0, 0, 0.6); font-weight: bold; height: 1.86em; box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.15); }
+#panel { background-color: rgba(0, 0, 0, 0.4); font-weight: bold; height: 2em; box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.15); }
 
 #panel.unlock-screen, #panel.login-screen, #panel.lock-screen { background-color: transparent; }
 


### PR DESCRIPTION
Blyr's blur height is more than panel height. The windows can't attach top pannel.
Before:
![imagen](https://user-images.githubusercontent.com/17345775/39077402-da4dc46a-4501-11e8-91ad-c08b9a637dce.png)
After: 
![imagen](https://user-images.githubusercontent.com/17345775/39077439-09eff0f8-4502-11e8-8b4c-156f96968283.png)
I add more traspareny for make this more pretty with blyr ^^

Sorry for my bad english